### PR TITLE
Fixed trade error & added changelogs

### DIFF
--- a/source/assets/js/UI.js
+++ b/source/assets/js/UI.js
@@ -7,6 +7,7 @@ $(function () {
     // Get the modal
     var modal = document.getElementById('helpModal');
     var changelogs = document.getElementById('changelogsModal');
+    var prompt = document.getElementById('prompt')
 
     // Get the button that opens the modal
     var btn = document.getElementById("helpBtn");
@@ -15,6 +16,7 @@ $(function () {
     // Get the <span> element that closes the modal
     var span = document.getElementsByClassName("close")[0];
     var changelogsSpan = document.getElementById("closeChangeLogs");
+    var promptSpan = document.getElementById("closePrompt");
 
     // When the user clicks the button, open the modal 
     btn.onclick = function () {
@@ -35,6 +37,10 @@ $(function () {
       changelogs.style.display = "none";
     }
 
+    promptSpan.onclick = function() {
+      prompt.style.display = "none";
+    }
+
     // When the user clicks anywhere outside of the modal, close it
     window.onclick = function (event) {
       if (event.target == modal) {
@@ -42,6 +48,10 @@ $(function () {
       }
       if (event.target == changelogs) {
         changelogs.style.display = "none";
+      }
+
+      if (event.target == prompt) {
+        prompt.style.display = "none";
       }
     }
 

--- a/source/assets/js/UI.js
+++ b/source/assets/js/UI.js
@@ -6,16 +6,24 @@ $(function () {
 
     // Get the modal
     var modal = document.getElementById('helpModal');
+    var changelogs = document.getElementById('changelogsModal');
 
     // Get the button that opens the modal
     var btn = document.getElementById("helpBtn");
+    var changelogsBtn = document.getElementById("ChangelogsBtn");
 
     // Get the <span> element that closes the modal
     var span = document.getElementsByClassName("close")[0];
+    var changelogsSpan = document.getElementById("closeChangeLogs");
 
     // When the user clicks the button, open the modal 
     btn.onclick = function () {
       modal.style.display = "block";
+    }
+
+    changelogsBtn.onclick = function () {
+      modal.style.display = "none";
+      changelogs.style.display = "block";
     }
 
     // When the user clicks on <span> (x), close the modal
@@ -23,10 +31,17 @@ $(function () {
       modal.style.display = "none";
     }
 
+    changelogsSpan.onclick = function () {
+      changelogs.style.display = "none";
+    }
+
     // When the user clicks anywhere outside of the modal, close it
     window.onclick = function (event) {
       if (event.target == modal) {
         modal.style.display = "none";
+      }
+      if (event.target == changelogs) {
+        changelogs.style.display = "none";
       }
     }
 

--- a/source/assets/js/backend.js
+++ b/source/assets/js/backend.js
@@ -209,7 +209,7 @@ function LoadConfiguration() {
   $("#trade-save-log").prop('checked', Config.TradeOptions ? Config.TradeOptions.SaveLog : true)
   $("#trade-enable-modal").prop('checked', Config.TradeOptions ? Config.TradeOptions.ShowModal : true)
   $("#trade-enable-popups").prop('checked', Config.TradeOptions ? Config.TradeOptions.ShowPopups : true)
-  if (Config.TradeOptions && Config.TradeOptions.LogLocation.length > 3) {
+  if (Config.TradeOptions && Config.TradeOptions.LogLocation && Config.TradeOptions.LogLocation.length > 3) {
 
     $("#trade-log-location").css("display", "none");
     $("#trade-log-location-template").css("display", "block");
@@ -229,6 +229,26 @@ function LoadConfiguration() {
   if (Config.GeneralOptions.SyncTeams) {
     ToggleSyncTeams();
   }
+
+  const request = require('request');
+
+  request("https://api.github.com/repos/AlphaConsole/AlphaConsoleElectron/releases", {
+    headers: {
+      "User-Agent": "AlphaConsole"
+    }
+  }, (err, result, body) => {
+    let data = JSON.parse(body);
+    data = [data[0], data[1], data[2]];
+    let text = data.map(t => {
+      let temp = `<h3>Update ${t.tag_name}</h3><p>${t.body.replace(/-/g, "<br/>-")}</p>`;
+      temp = temp.replace("</h3><p><br/>", "</h3><p>");
+      console.log(temp);
+
+      return temp;
+    }).join("<br/>");
+
+    $("#changelogsInfo").html(text);
+  })
 
 }
 

--- a/source/assets/js/backend.js
+++ b/source/assets/js/backend.js
@@ -242,12 +242,16 @@ function LoadConfiguration() {
     let text = data.map(t => {
       let temp = `<h3>Update ${t.tag_name}</h3><p>${t.body.replace(/-/g, "<br/>-")}</p>`;
       temp = temp.replace("</h3><p><br/>", "</h3><p>");
-      console.log(temp);
 
       return temp;
     }).join("<br/>");
 
     $("#changelogsInfo").html(text);
+    if ('v' + require('electron').remote.app.getVersion() !== data[0].tag_name) {
+      $("#promptTitle").html("New version available");
+      $("#promptContent").html("<p class=\"text-center\">Download the new version <a href=\"https://github.com/alphaconsole/AlphaConsoleElectron/releases\">here</a>!</p>")
+      $("#prompt").css("display", "block")
+    }
   })
 
 }

--- a/source/assets/js/backend.js
+++ b/source/assets/js/backend.js
@@ -247,11 +247,6 @@ function LoadConfiguration() {
     }).join("<br/>");
 
     $("#changelogsInfo").html(text);
-    if ('v' + require('electron').remote.app.getVersion() !== data[0].tag_name) {
-      $("#promptTitle").html("New version available");
-      $("#promptContent").html("<p class=\"text-center\">Download the new version <a href=\"https://github.com/alphaconsole/AlphaConsoleElectron/releases\">here</a>!</p>")
-      $("#prompt").css("display", "block")
-    }
   })
 
 }

--- a/source/index.html
+++ b/source/index.html
@@ -1214,6 +1214,25 @@
 
   </div>
 
+  <div id="prompt" class="modal" style="z-index: 1000000">
+
+    <!-- Modal content -->
+    <div class="modal-content">
+      <div class="modal-header">
+        <p class="font-quarcaL p-2 w-100 heading-title" id="promptTitle"></p>
+        <span id="closePrompt" class="close lnr lnr-cross pl-2 pr-2"></span>
+      </div>
+      <div class="modal-body">
+        
+        <p id="promptContent" style="margin-bottom: 20px"></p>
+
+      </div>
+      <div class="modal-footer">
+      </div>
+    </div>
+
+  </div>
+
   <div id="changelogsModal" class="modal" style="z-index: 1000000">
 
     <!-- Modal content -->

--- a/source/index.html
+++ b/source/index.html
@@ -1156,7 +1156,7 @@
   <!-- Footer End ./// -->
 
   <!-- Help Modal -->
-  <div id="helpModal" class="modal">
+  <div id="helpModal" class="modal" style="z-index: 1000000">
 
     <!-- Modal content -->
     <div class="modal-content">
@@ -1202,7 +1202,29 @@
           <div class="col-3  pr-0">
             <a href="http://www.alphaconsole.net" style="color:#fff;" class="font-quarcaL btn btn-acc w-100">WEBSITE</a>
           </div>
+          <div class="col-3  pr-0">
+            <a id="ChangelogsBtn" href="#" style="color:#fff;" class="font-quarcaL btn btn-acc w-100">CHANGELOGS</a>
+          </div>
         </div>
+
+      </div>
+      <div class="modal-footer">
+      </div>
+    </div>
+
+  </div>
+
+  <div id="changelogsModal" class="modal" style="z-index: 1000000">
+
+    <!-- Modal content -->
+    <div class="modal-content">
+      <div class="modal-header">
+        <p class="font-quarcaL p-2 w-100 heading-title">CHANGELOGS</p>
+        <span id="closeChangeLogs" class="close lnr lnr-cross pl-2 pr-2"></span>
+      </div>
+      <div class="modal-body">
+        
+        <p id="changelogsInfo" style="margin-bottom: 20px"></p>
 
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
- Added a new Modal for changelogs. Button is next to social links on the `INFO/HELP` modal.
- Changelogs modal gets filled with data from the AlphaConsoleElectron releases page (last 3 releases)
- Made both modals higher on the `z-index` whereby the "Toggle for both sides" button wasn't above the modal.
- Fixed an error whereby nothing would brake but just had less errors in console (Trade option related)